### PR TITLE
Implement IR-Docs, and update CI

### DIFF
--- a/.changeset/flat-squids-enjoy.md
+++ b/.changeset/flat-squids-enjoy.md
@@ -1,0 +1,12 @@
+---
+"@infinitered/infinite-red-ai": patch
+"@infinitered/react-native-mlkit-core": patch
+"@infinitered/react-native-mlkit-face-detection": patch
+"@infinitered/react-native-mlkit-image-labeling": patch
+"@infinitered/react-native-mlkit-object-detection": patch
+"docusaurus": patch
+"@infinitered/eslint-config-react-native-mlkit": patch
+"@infinitered/tsconfig": patch
+---
+
+test bump

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Build everything including docs
           command: yarn ci:build
-      - publish-docs/build-docs:
+      - publish-docs/build_docs:
           project_name: 'react-native-mlkit'
           source_docs_dir: packages/docusaurus/docs/docs
           label: "React Native MLKit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,14 +43,14 @@ jobs:
       - run:
           name: Build everything including docs
           command: yarn ci:build
-      - publish-docs/build_docs:
-          project_name: 'react-native-mlkit'
-          source_docs_dir: packages/docusaurus/docs/docs
-          label: "React Native MLKit"
-          description: "Use MLKit Models in React Native apps"
-          target_repo: "git@github.com:infinitered/orb-publish-docs.git"
-          git_username: "Infinite Red CI"
-          git_email: "ci@infinite.red"
+  publish-docs/build_docs:
+    project_name: 'react-native-mlkit'
+    source_docs_dir: packages/docusaurus/docs/docs
+    label: "React Native MLKit"
+    description: "Use MLKit Models in React Native apps"
+    target_repo: "git@github.com:infinitered/orb-publish-docs.git"
+    git_username: "Infinite Red CI"
+    git_email: "ci@infinite.red"
 # Workflows
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ workflows:
     when:
       equal: ["release", << pipeline.parameters.GHA_Event >>]
     jobs:
-      - publish-docs/publish-docs:
+      - publish-docs/publish_docs:
           project_name: 'react-native-mlkit'
           source_docs_dir: packages/docusaurus/docs/docs
           label: "React Native MLKit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
 
 orbs:
-  publish-docs: infinitered/publish-docs@0.1.8
+  publish-docs: infinitered/publish-docs@0.1
 
 # Docker defaults
 defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,22 @@
 
 version: 2.1
 
+parameters:
+  # GHA Params are set when the orb is called from a GitHub Action
+  # see: https://circleci.com/blog/trigger-circleci-pipeline-github-action/
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
+
 orbs:
   publish-docs: infinitered/publish-docs@dev:alpha
 
@@ -51,6 +67,22 @@ workflows:
     jobs:
       - test_and_build
       - publish-docs/build_docs:
+          project_name: 'react-native-mlkit'
+          source_docs_dir: packages/docusaurus/docs/docs
+          label: "React Native MLKit"
+          description: "Use MLKit Models in React Native apps"
+          target_repo: "git@github.com:infinitered/ir-docs.git"
+          git_username: "Infinite Red CI"
+          git_email: "ci@infinite.red"
+  # publishes docs to the IR-Docs repo
+  #  - Triggered from a GitHub Action, because the changeset release action is
+  #    not available in CircleCI yet.
+  #  - See:
+  release-docs:
+    when:
+      equal: ["release", << pipeline.parameters.GHA_Event >>]
+    jobs:
+      - publish-docs/publish-docs:
           project_name: 'react-native-mlkit'
           source_docs_dir: packages/docusaurus/docs/docs
           label: "React Native MLKit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,17 +43,18 @@ jobs:
       - run:
           name: Build everything including docs
           command: yarn ci:build
-  publish-docs/build_docs:
-    project_name: 'react-native-mlkit'
-    source_docs_dir: packages/docusaurus/docs/docs
-    label: "React Native MLKit"
-    description: "Use MLKit Models in React Native apps"
-    target_repo: "git@github.com:infinitered/orb-publish-docs.git"
-    git_username: "Infinite Red CI"
-    git_email: "ci@infinite.red"
+
 # Workflows
 workflows:
   version: 2
   build-and-test:
     jobs:
       - test_and_build
+      - publish-docs/build_docs:
+          project_name: 'react-native-mlkit'
+          source_docs_dir: packages/docusaurus/docs/docs
+          label: "React Native MLKit"
+          description: "Use MLKit Models in React Native apps"
+          target_repo: "git@github.com:infinitered/orb-publish-docs.git"
+          git_username: "Infinite Red CI"
+          git_email: "ci@infinite.red"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,6 @@ workflows:
           source_docs_dir: packages/docusaurus/docs/docs
           label: "React Native MLKit"
           description: "Use MLKit Models in React Native apps"
-          target_repo: "git@github.com:infinitered/orb-publish-docs.git"
+          target_repo: "git@github.com:infinitered/ir-docs.git"
           git_username: "Infinite Red CI"
           git_email: "ci@infinite.red"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
 
 orbs:
-  publish-docs: infinitered/publish-docs@dev:alpha
+  publish-docs: infinitered/publish-docs@0.1.8
 
 # Docker defaults
 defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
+---
+
 version: 2.1
+
+orbs:
+  publish-docs: infinitered/publish-docs@dev:alpha
 
 # Docker defaults
 defaults: &defaults
@@ -38,7 +43,14 @@ jobs:
       - run:
           name: Build everything including docs
           command: yarn ci:build
-
+      - publish-docs/build-docs:
+          project_name: 'react-native-mlkit'
+          source_docs_dir: packages/docusaurus/docs/docs
+          label: "React Native MLKit"
+          description: "Use MLKit Models in React Native apps"
+          target_repo: "git@github.com:infinitered/orb-publish-docs.git"
+          git_username: "Infinite Red CI"
+          git_email: "ci@infinite.red"
 # Workflows
 workflows:
   version: 2

--- a/.github/workflows/ir-docs.yml
+++ b/.github/workflows/ir-docs.yml
@@ -10,4 +10,4 @@ jobs:
         id: react-native-mlkit-publish-docs
         uses: circleci/trigger_circleci_pipeline@v1.0
         env:
-          CCI_TOKEN: $
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}

--- a/.github/workflows/ir-docs.yml
+++ b/.github/workflows/ir-docs.yml
@@ -1,0 +1,13 @@
+---
+on:
+  release:
+    types: [published]
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Trigger CircleCI publish-docs pipeline"
+        id: react-native-mlkit-publish-docs
+        uses: circleci/trigger_circleci_pipeline@v1.0
+        env:
+          CCI_TOKEN: $

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,3 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 
-

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -16,3 +16,4 @@ jobs:
           prerelease: false
           files: |
             LICENSE.txt
+

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,18 @@
+---
+name: "tagged-release"
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            LICENSE.txt


### PR DESCRIPTION
As part of an effort to simplify and standardize the process of writing docs across IR open source, this adds several new CI/CD actions.

## Github Actions
- `tagged-release` -- automatically creates a release when a version tag is created by changesets
- `ir-docs` -- on published releases triggers the circleCI orb that publishes the docs to the `ir-docs` site

## CircleCI
- Adds the `release-docs`workflow which uses the infinitered/publish-docs orb to publish the docs
- Adds a `publish-docs/build_docs` step to the `build-and-test` workflow to build the docs and check for broken links etc.

Docs will still be published to the current site for now, but will also be sent to `ir-docs`.
