### PR TITLE
Add contributing section to the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+Please see the full documentaion
+at [https://docs.infinite.red/react-native-mlkit](https://docs.infinite.red/react-native-mlkit)
+
+Or for a local version check the `~/docs/` folder

--- a/apps/README.md
+++ b/apps/README.md
@@ -3,6 +3,6 @@
 # Apps
 
 - **InfiniteRedAI** - demo application showcasing the various RNMLKit options
-- **docs** -- placeholder web app for the project's docs
+
 
 

--- a/docs/contributing/_category_.json
+++ b/docs/contributing/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Running the Example App",
+  "position": 99,
+  "link": {
+    "type": "generated-index",
+    "description": "How to run the included example application."
+  }
+}

--- a/docs/contributing/_category_.json
+++ b/docs/contributing/_category_.json
@@ -1,6 +1,6 @@
 {
-  "label": "Running the Example App",
-  "position": 99,
+  "label": "Contributing",
+  "position": 1,
   "link": {
     "type": "generated-index",
     "description": "How to run the included example application."

--- a/docs/contributing/adding-a-new-module.md
+++ b/docs/contributing/adding-a-new-module.md
@@ -1,0 +1,5 @@
+---
+sidebar_position: 99
+---
+
+# adding-a-new-module.md

--- a/docs/contributing/adding-a-new-module.md
+++ b/docs/contributing/adding-a-new-module.md
@@ -2,4 +2,46 @@
 sidebar_position: 99
 ---
 
-# adding-a-new-module.md
+# Adding a new module
+
+To add a new module to the monorepo, there are a couple of things you need to do. This guide will walk you through the
+process.
+
+## 1. Create a new module
+
+Either copy and paste an existing module and rename it, or create a new directory in the `modules` directory, and add
+the files required. See the Expo Modules API documentation for more information.
+
+## 2. Add the module to the example app
+
+Add your module as a dependency to the example app in `apps/InfinteRedAI`, run `yarn install` in the example app, and
+then run `yarn prebuild` to generate the native code.
+
+## 3. Add the module to the documentation
+
+Create a new folder in /docs/ with the unique part of the name of your module. For example, if your module is
+called `react-native-mlkit-barcode-scanner`, create a new folder called `barcode-scanner` in the `/docs/` directory.
+
+Add a `category.json` file to the new folder with the following content:
+
+```json
+{
+  "label": "Barcode Scanner",
+  "position": 100
+}
+```
+
+Use the position property to order of the module alphabeticallu in the sidebar. Use the number equidistant from the one
+before and after, so there will be space for more modules to be added.
+
+Add a `index.md` file to the new folder with the following content:
+
+```markdown
+---
+sidebar_position: 1
+---
+
+# Barcode Scanner
+
+<<Content goes here>>
+```

--- a/docs/contributing/adding-a-new-module.md
+++ b/docs/contributing/adding-a-new-module.md
@@ -9,7 +9,7 @@ process.
 
 ## 1. Create a new module
 
-Either copy and paste an existing module and rename it, or create a new directory in the `modules` directory, and add
+Either copy and paste an existing module and rename it, or create a module by running `npx create-expo-module module-name --local` in the  `modules` directory, and add
 the files required. See the Expo Modules API documentation for more information.
 
 ## 2. Add the module to the example app

--- a/docs/contributing/changesets-versions-and-releases.md
+++ b/docs/contributing/changesets-versions-and-releases.md
@@ -2,4 +2,54 @@
 sidebar_position: 99
 ---
 
-# releases-and-versions.md
+# Changesets, Versions, and Releases
+
+## Using Changesets in the Repository
+
+Changesets is a tool we use to manage versioning and changelogs in our monorepo efficiently. It allows us to track
+changes to the packages within the repository, ensuring that when we release updates, all dependent packages are
+versioned correctly, and their changelogs are updated appropriately.
+
+### Getting Started with Changesets
+
+To introduce a change or a new feature that you believe should trigger a version update of a package (or packages),
+you'll need to create a changeset. A changeset is essentially a record of what packages need to be released and how (
+major, minor, or patch).
+
+1. **Creating a Changeset**
+
+   After making your changes in the repository, run the following command at the root:
+
+   ```bash
+   yarn changeset
+   ```
+
+   This command will prompt you to select the packages that have changed, as well as the type of change (major, minor,
+   or patch). It will then generate a `.md` file in the `.changeset` directory describing these changes. Include this
+   file in your pull request.
+
+2. **Reviewing Changesets in PRs**
+
+   Changesets included in pull requests are reviewed as part of the code review process. This ensures that the
+   versioning and changelogs will accurately reflect the changes once merged.
+
+3. **Releasing Changes**
+
+   Our release process is automated through GitHub Actions and utilizes the custom `release` script defined in
+   our `scripts` directory. This process includes building the project, publishing updated packages to npm, and pushing
+   tags to the repository.
+
+   The `yarn release` command executes the steps defined in `scripts/release.mjs`, handling the complexities of
+   building, publishing,
+   and updating the repository accordingly.
+
+### Important Considerations
+
+- Ensure you run `yarn changeset` after making your changes but before creating your pull request.
+- For a detailed explanation of the impact of your changes (major, minor, or patch), refer
+  to [Semantic Versioning](https://semver.org/).
+- The configuration for changesets can be found in `.changeset/config.json`. This configuration controls aspects like
+  which branches are used for releases, commit messages, and more.
+
+By adhering to these guidelines and utilizing changesets, you help maintain the project's versioning integrity and
+contribute to the clear documentation of changes across releases.

--- a/docs/contributing/changesets-versions-and-releases.md
+++ b/docs/contributing/changesets-versions-and-releases.md
@@ -1,0 +1,5 @@
+---
+sidebar_position: 99
+---
+
+# releases-and-versions.md

--- a/docs/contributing/editing-native-code.md
+++ b/docs/contributing/editing-native-code.md
@@ -4,7 +4,7 @@ sidebar_position: 99
 
 # Editing Native Code
 
-If you just open on of the native files in the modules directly, you'll probably see a lot of red squiggles. This is
+If you just open one of the native files in the modules directly, you'll probably see a lot of red squiggles. This is
 because the native code is written in Kotlin and Swift, and they depend on other native modules.
 
 To edit these modules with the fullgit context of the project, you'll need to open the example app in Xcode and/or

--- a/docs/contributing/editing-native-code.md
+++ b/docs/contributing/editing-native-code.md
@@ -1,0 +1,5 @@
+---
+sidebar_position: 99
+---
+
+# editing-native-code.md

--- a/docs/contributing/editing-native-code.md
+++ b/docs/contributing/editing-native-code.md
@@ -8,8 +8,7 @@ If you just open one of the native files in the modules directly, you'll probabl
 because the native code is written in Kotlin and Swift, and they depend on other native modules.
 
 To edit these modules with the full git context of the project, you'll need to open the example app in Xcode and/or
-Android
-Studio, then open the native files from there.
+Android gitStudio, then open the native files from there.
 
 This will allow the IDE to understand the full context of the project, which in turn enables proper syntax highlighting,
 autocompletion, and linting.

--- a/docs/contributing/editing-native-code.md
+++ b/docs/contributing/editing-native-code.md
@@ -2,4 +2,41 @@
 sidebar_position: 99
 ---
 
-# editing-native-code.md
+# Editing Native Code
+
+If you just open on of the native files in the modules directly, you'll probably see a lot of red squiggles. This is
+because the native code is written in Kotlin and Swift, and they depend on other native modules.
+
+To edit these modules with the fullgit context of the project, you'll need to open the example app in Xcode and/or
+Android
+Studio, then open the native files from there.
+
+This will allow the IDE to understand the full context of the project, which in turn enables proper syntax highlighting,
+autocompletion, and linting.
+
+## iOS
+
+1. If you haven't already, run the `prebuild` script to create the ios example app
+   ```shell
+   cd apps/InfiniteRedAI
+   yarn prebuild
+   ```
+2. Open Xcode and open the `./apps/InfiniteRedAI/ios` directory.
+3. In the project navigator, find the module you want to edit. It will be
+   under `Pods` > `Development Pods` > `react-native-mlkit-[module name]`.
+4. Open the `.swift` file you want to edit, and make your changes there.
+
+## Android
+
+1. If you haven't already, run the `prebuild` script to create the android example app
+   ```shell
+   cd apps/InfiniteRedAI
+   yarn prebuild
+   ```
+2. Open Android Studio and open the `./apps/InfiniteRedAI/android` directory.
+3. In the project navigator, find the module you want to edit.
+    - In the 'Project' view, it will be
+      under `infiniteRedAI` >  `[android] [infinitered-react-native-mlkit-[module name]]`
+    - In the `Android` view, it will be under `infinitered-react-native-mlkit-[module name]`
+4. Browse to the `.kt` file you want to edit, and make your changes there.
+

--- a/docs/contributing/editing-native-code.md
+++ b/docs/contributing/editing-native-code.md
@@ -8,7 +8,7 @@ If you just open one of the native files in the modules directly, you'll probabl
 because the native code is written in Kotlin and Swift, and they depend on other native modules.
 
 To edit these modules with the full git context of the project, you'll need to open the example app in Xcode and/or
-Android gitStudio, then open the native files from there.
+Android Studio, then open the native files from there.
 
 This will allow the IDE to understand the full context of the project, which in turn enables proper syntax highlighting,
 autocompletion, and linting.

--- a/docs/contributing/editing-native-code.md
+++ b/docs/contributing/editing-native-code.md
@@ -7,7 +7,7 @@ sidebar_position: 99
 If you just open one of the native files in the modules directly, you'll probably see a lot of red squiggles. This is
 because the native code is written in Kotlin and Swift, and they depend on other native modules.
 
-To edit these modules with the fullgit context of the project, you'll need to open the example app in Xcode and/or
+To edit these modules with the full git context of the project, you'll need to open the example app in Xcode and/or
 Android
 Studio, then open the native files from there.
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 1
+---
+
+# Contributing to `react-native-mlkit`
+
+We are excited to have you contribute to `react-native-mlkit`! This documentation will help you get started with the
+project.
+
+Sections:
+
+- [Editing Native Code](./editing-native-code.md)
+- [Adding a new module](./adding-a-new-module.md)
+- [Project Structure and Management](./project-structure-and-management.md)
+- [Changesets, Versions, and Releases](./changesets-versions-and-releases.md)s

--- a/docs/contributing/project-structure-and-management.md
+++ b/docs/contributing/project-structure-and-management.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 99
+---
+
+# Project Structure and Management
+
+This document outlines the structure of our monorepo and the tools and practices we use to manage it.
+
+## Monorepo Structure
+
+Our monorepo consists of several key directories, each serving a specific purpose:
+
+- **apps/**: Contains the example app(s) demonstrating how to use the modules. It's a great place for testing and
+  showcasing real-world usage.
+- **docs/**: Houses the documentation for the modules and contribution guidelines. We use Docusaurus for a smooth
+  documentation experience.
+- **modules/**: The core of our monorepo, this directory contains the source code for each module. Each module is a
+  separate npm package.
+- **packages/**: Includes internal packages such as configurations for ESLint, TypeScript, and other tooling that
+  supports development across the monorepo.
+- **scripts/**: Contains shell scripts and other utilities for managing the monorepo, like setup and release scripts.
+
+## Managing the Monorepo
+
+### Turbo
+
+We use [Turbo](https://turborepo.org/) to manage our monorepo. Turbo optimizes the build process by caching builds and
+only rebuilding what's necessary. It's highly efficient for testing, building, and deploying code across multiple
+projects within the monorepo.
+
+### Yarn Workspaces
+
+[Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) is another key tool in our monorepo management
+strategy. It allows us to install dependencies for all our projects with a single `yarn install` command, link
+interdependent projects within the monorepo, and manage a single `node_modules` directory at the root level, reducing
+install time and disk space usage.
+
+### Changesets
+
+Versioning and publishing are handled through [Changesets](https://github.com/atlassian/changesets), a tool that manages
+versioning for multi-package repositories. Changesets ensure that version numbers are updated correctly across packages,
+changelogs are generated, and packages are published in sync.
+
+### Continuous Integration (CI)
+
+Our CI pipeline is configured to build, test, and deploy changes across the monorepo. It ensures that every commit
+adheres to our coding standards, passes all tests, and that documentation is updated accordingly.
+
+### Scripts
+
+The `scripts/` directory contains custom scripts to automate common monorepo tasks:
+
+- `setup.sh` for initializing the development environment.
+- `release.mjs` for managing releases across packages.
+- Additional utility scripts for linting, testing, and cleaning the repo.
+
+## Conclusion
+
+Our monorepo structure and the tools we've chosen are integral to our development workflow. They allow us to efficiently
+manage multiple related projects, ensure consistency across our codebase, and streamline our CI/CD processes. By
+understanding and adhering to our monorepo management practices, contributors can effectively navigate, develop, and
+contribute to our projects.


### PR DESCRIPTION
Adds the section with some basic information -- we can keep extending it as more people join and more questions come up.

Current sections are:
- Contributing to `react-native-mlkit` (table of contents)
- Editing Native Code
- Adding a new module
- Project Structure and Management
- Changesets, Versions, and Releases
