### PR TITLE
docs(doc-scanner): fix mlkit options doc link

### DIFF
--- a/docs/document-scanner/options.md
+++ b/docs/document-scanner/options.md
@@ -17,7 +17,7 @@ A `DocumentScannerOptions` object is used to configure the behavior of the docum
 
 
 For more information on these options
-see [the MLKit Docs](https://developers.google.com/ml-kit/vision/object-detection/ios#1.-configure-the-object-detector)
+see [the MLKit Docs](https://developers.google.com/ml-kit/vision/doc-scanner/android)
 
 ### Example Usage
 


### PR DESCRIPTION
## Why
Because you have to miss at least one link in a markdown file each PR