### PR TITLE
ci: remove obsolete command to deploy docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
     "version": "changeset version && yarn install --mode update-lockfile",
     "ci:build": "turbo run build --filter=@infinitered/react-native-mlkit-core --no-cache && turbo run build --filter=!@infinitered/react-native-mlkit-core --no-cache",
     "ci:publish": "changeset publish",
-    "ci:deploy:docs": "yarn workspace @infinitered/react-native-mlkit-docs deploy",
     "ci:push-tags": "git push --follow-tags",
-    "release": "yarn ci:build && yarn ci:publish && yarn ci:push-tags && yarn ci:deploy:docs "
+    "release": "yarn ci:build && yarn ci:publish && yarn ci:push-tags"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
Problem:
 - release action was failing because it tried to push to non-existent gh pages repo
- this was because the`deploy:docs` script was still being called by the `release` script

Solution:
- remove obsolete `deploy:docs` script, as this is now handled by CircleCI