### PR TITLE
Fix readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 RNMLKit provides Expo modules that allow developers to use MLKit native libraries in their Expo apps.
 
-- [Document Scanner](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-document-scanner)
-- [Face Detection](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-face-detection)
-- [Image Labeling](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-image-labeling)
-- [Object Detection](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-object-detection)
+- [Document Scanner](https://docs.infinite.red/react-native-mlkit/document-scanner/)
+- [Face Detection](https://docs.infinite.red/react-native-mlkit/face-detection/)
+- [Image Labeling](https://docs.infinite.red/react-native-mlkit/image-labeling/)
+- [Object Detection](https://docs.infinite.red/react-native-mlkit/object-detection/)
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 RNMLKit provides Expo modules that allow developers to use MLKit native libraries in their Expo apps.
 
-- [Document Scanner](https://https://infinitered.github.io/react-native-mlkit/document-scanner/getting-started/)
-- [Face Detection](https://https://infinitered.github.io/react-native-mlkit/face-detection/getting-started/)
+- [Document Scanner](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-document-scanner)
+- [Face Detection](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-face-detection)
 - [Image Labeling](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-image-labeling)
 - [Object Detection](https://github.com/infinitered/react-native-mlkit/tree/main/modules/react-native-mlkit-object-detection)
 

--- a/docs/document-scanner/index.md
+++ b/docs/document-scanner/index.md
@@ -16,10 +16,10 @@ Install like any other npm package:
 
 ```bash
 #yarn
-yarn add react-native-mlkit-document-scanner
+yarn add @infinitered/react-native-mlkit-document-scanner
 
 #npm
-npm install react-native-mlkit-document-scanner
+npm install @infinitered/react-native-mlkit-document-scanner
 ```
 
 ## Basic Usage
@@ -31,7 +31,7 @@ Use the `launchDocumentScannerAsync` method to initiate the document scanner mod
 ```tsx
 // App.tsx
 import { View, Button } from "react-native";
-import { launchDocumentScannerAsync } from "react-native-mlkit-document-scanner";
+import { launchDocumentScannerAsync } from "@infinitered/react-native-mlkit-document-scanner";
 
 function App() {
   return (

--- a/docs/object-detection/index.md
+++ b/docs/object-detection/index.md
@@ -16,10 +16,10 @@ Install like any other npm package:
 
 ```bash
 #yarn
-yarn add react-native-mlkit-object-detection
+yarn add @infinitered/react-native-mlkit-object-detection
 
 #npm
-npm install react-native-mlkit-object-detection
+npm install @infinitered/react-native-mlkit-object-detection
 ```
 
 ## Basic Usage
@@ -35,7 +35,7 @@ available via React context.
 import {
   AssetRecord,
   useObjectDetectionModels,
-} from "react-native-mlkit-object-detection";
+} from "@infinitered/react-native-mlkit-object-detection";
 
 // For descriptions of options for default models see link below this snipped.
 function App() {

--- a/modules/react-native-mlkit-document-scanner/README.md
+++ b/modules/react-native-mlkit-document-scanner/README.md
@@ -20,7 +20,7 @@ continuing.
 ### Add the package to your npm dependencies
 
 ```
-npm install react-native-mlkit-document-scanner
+npm install @infinitered/react-native-mlkit-document-scanner
 ```
 
 ### Configure for iOS

--- a/modules/react-native-mlkit-face-detection/README.md
+++ b/modules/react-native-mlkit-face-detection/README.md
@@ -20,7 +20,7 @@ continuing.
 ### Add the package to your npm dependencies
 
 ```
-npm install react-native-mlkit-face-detection
+npm install @infinitered/react-native-mlkit-face-detection
 ```
 
 ### Configure for iOS

--- a/modules/react-native-mlkit-object-detection/README.md
+++ b/modules/react-native-mlkit-object-detection/README.md
@@ -31,10 +31,10 @@ Install like any other npm package:
 
 ```bash
 #yarn
-yarn add react-native-mlkit-object-detection
+yarn add @infinitered/react-native-mlkit-object-detection
 
 #npm
-npm install react-native-mlkit-object-detection
+npm install @infinitered/react-native-mlkit-object-detection
 ```
 
 ## Basic Usage with Default Model
@@ -50,7 +50,7 @@ available via React context.
 import {
   AssetRecord,
   useObjectDetectionModels,
-} from "react-native-mlkit-object-detection";
+} from "@infinitered/react-native-mlkit-object-detection";
 
 // For descriptions of options for default models see link below this snipped.
 function App() {
@@ -173,7 +173,7 @@ First define an AssetRecord object with the details of your model, and your desi
 import {
   AssetRecord,
   useObjectDetectionModels,
-} from "react-native-mlkit-object-detection";
+} from "@infinitered/react-native-mlkit-object-detection";
 
 const MODELS: AssetRecord = {
   // the name you'll use to refer to the model

--- a/packages/docusaurus/docs/docs/object-detection/index.md
+++ b/packages/docusaurus/docs/docs/object-detection/index.md
@@ -16,10 +16,10 @@ Install like any other npm package:
 
 ```bash
 #yarn
-yarn add react-native-mlkit-object-detection
+yarn add @infinitered/react-native-mlkit-object-detection
 
 #npm
-npm install react-native-mlkit-object-detection
+npm install @infinitered/react-native-mlkit-object-detection
 ```
 
 ## Basic Usage
@@ -35,7 +35,7 @@ available via React context.
 import {
   AssetRecord,
   useObjectDetectionModels,
-} from "react-native-mlkit-object-detection";
+} from "@infinitered/react-native-mlkit-object-detection";
 
 // For descriptions of options for default models see link below this snipped.
 function App() {


### PR DESCRIPTION
This PR fixes the READMEs:

* At the root of the project, to correct the links to the various modules (Document Scanner and Face Detection). I have updated the links for the Document Scanner and Face Detection modules to redirect to the correct GitHub subfolders. Additionally, I made this choice, but if it is better to change it to redirect to https://docs.infinite.red/react-native-mlkit/ instead, I can of course do that for all modules.

* In the various markdown files to add "@infinitered/" to the package names where it was missing.