### PR TITLE
Fix Image Labeling result container layout

### DIFF
--- a/apps/ExampleApp/app/screens/ImageLabelingScreen.tsx
+++ b/apps/ExampleApp/app/screens/ImageLabelingScreen.tsx
@@ -124,9 +124,9 @@ const ImageLabelingScreenComponent: FC<ImageLabelingScreenProps> = observer(
           }}
         />
 
-        <View style={$resultContainer}>
-          {result &&
-            result.map((item) => {
+        {result && (
+          <View style={$resultContainer}>
+            {result.map((item) => {
               return (
                 <View key={item.text} style={$resultRow}>
                   <Text style={$resultText} text={item.text} />
@@ -137,7 +137,8 @@ const ImageLabelingScreenComponent: FC<ImageLabelingScreenProps> = observer(
                 </View>
               )
             })}
-        </View>
+          </View>
+        )}
       </Screen>
     )
   },
@@ -168,8 +169,8 @@ const $description: TextStyle = {
 
 const $resultContainer: ViewStyle = {
   width: "100%",
-  height: 200,
   borderWidth: 1,
+  marginVertical: 24,
 }
 const $resultRow: ViewStyle = {
   flexDirection: "row",


### PR DESCRIPTION
- This fixes the broken result container layout on Image Labeling screen

|before|after|
|---|---|
|![IMG_5840](https://github.com/user-attachments/assets/2d856b4c-4ec5-4e6c-b061-53a1a7c6815e)|![IMG_5841](https://github.com/user-attachments/assets/6250ae6e-ed39-42b4-a07f-d9d4a61b9952)|