### PR TITLE
fix(web): do not throw error on module init

### DIFF
--- a/.changeset/clean-singers-clap.md
+++ b/.changeset/clean-singers-clap.md
@@ -1,0 +1,5 @@
+---
+"@infinitered/react-native-mlkit-face-detection": minor
+---
+
+fix(web): do not throw error on module init

--- a/modules/react-native-mlkit-face-detection/src/constants.ts
+++ b/modules/react-native-mlkit-face-detection/src/constants.ts
@@ -1,0 +1,1 @@
+export const WEB_ERROR = "react-native-mlkit is not implemented on Web";

--- a/modules/react-native-mlkit-face-detection/src/context/ReactMLKitFaceDetectionContext.web.tsx
+++ b/modules/react-native-mlkit-face-detection/src/context/ReactMLKitFaceDetectionContext.web.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from "react";
+import { RNMLKitFaceDetectorOptions } from "../types";
+
+interface Props extends PropsWithChildren {
+  options?: RNMLKitFaceDetectorOptions;
+  deferInitialization?: boolean;
+}
+
+const RNMLKitFaceDetectionContextProvider = ({ children }: Props) => children;
+
+export default RNMLKitFaceDetectionContextProvider;

--- a/modules/react-native-mlkit-face-detection/src/hooks/useFaceDetector.web.tsx
+++ b/modules/react-native-mlkit-face-detection/src/hooks/useFaceDetector.web.tsx
@@ -1,0 +1,14 @@
+import { WEB_ERROR } from "../constants";
+
+const useFaceDetector = () => ({
+  detectFaces: () => {
+    throw new Error(WEB_ERROR);
+  },
+  error: null,
+  initialize: () => {
+    throw new Error(WEB_ERROR);
+  },
+  status: "ready",
+});
+
+export default useFaceDetector;

--- a/modules/react-native-mlkit-face-detection/src/hooks/useFacesInPhoto.web.tsx
+++ b/modules/react-native-mlkit-face-detection/src/hooks/useFacesInPhoto.web.tsx
@@ -1,0 +1,13 @@
+import { UseFaceDetectorReturnType } from "./useFacesInPhoto";
+import { WEB_ERROR } from "../constants";
+
+export function useFacesInPhoto(imageUri?: string): UseFaceDetectorReturnType {
+  return {
+    clearFaces: () =>    {
+      throw new Error(WEB_ERROR);
+    } ,
+    error: undefined,
+    status: "ready",
+    faces: [],
+  } as UseFaceDetectorReturnType;
+}


### PR DESCRIPTION
This PR uses face-detection module to showcase how we can handle Web by ignoring the module and throwing an error when trying to use hooks.