### PR TITLE
fix: sets static builds in core podspec to prevent dependency conflicts

### DIFF
--- a/.changeset/wet-cups-burn.md
+++ b/.changeset/wet-cups-burn.md
@@ -1,0 +1,5 @@
+---
+"@infinitered/react-native-mlkit-core": minor
+---
+
+fix: sets static builds in core podspec to prevent dependency conflicts

--- a/modules/react-native-mlkit-core/ios/RNMLKitCore.podspec
+++ b/modules/react-native-mlkit-core/ios/RNMLKitCore.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '13.0'
   s.swift_version  = '5.4'
   s.source         = { git: 'http://github.com/infinitered/react-native-mlkit' }
-
+  s.static_framework = true
   s.dependency 'MLKitVision'
   s.dependency 'ExpoModulesCore'
 
@@ -22,6 +22,10 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
+
+  def s.build_type
+    Pod::BuildType.static_library
+  end
 
   s.source_files = "**/*.{h,m,swift}"
 end


### PR DESCRIPTION
This PR configures `RNMLKitCore.podspec` to use static builds to prevent dependency conflicts
See: https://github.com/infinitered/react-native-mlkit/issues/169

## Why
- Prevents dependency conflicts when used alongside other libraries (like React Native Firebase)
- Follows CocoaPods best practices for React Native modules

## Impact
- No negative impact on existing implementations
- Helps prevent version conflicts with shared dependencies (like nanopb)
- Minimal change that follows standard CocoaPods patterns

## Testing
- [x] Tested with React Native Firebase
- [x] Verified basic MLKit functionality