### PR TITLE
chore: upgrade iOS deployment target to 15

### DIFF
--- a/apps/ExampleApp/app.json
+++ b/apps/ExampleApp/app.json
@@ -70,7 +70,7 @@
           "ios": {
             "newArchEnabled": false,
             "flipper": false,
-            "deploymentTarget": "13.4"
+            "deploymentTarget": "15.8.3"
           },
           "android": {
             "newArchEnabled": false,

--- a/modules/react-native-mlkit-core/ios/RNMLKitCore.podspec
+++ b/modules/react-native-mlkit-core/ios/RNMLKitCore.podspec
@@ -10,9 +10,10 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '15.8.3'
   s.swift_version  = '5.4'
   s.source         = { git: 'http://github.com/infinitered/react-native-mlkit' }
+  s.static_framework = true
 
   s.dependency 'MLKitVision'
   s.dependency 'ExpoModulesCore'

--- a/modules/react-native-mlkit-face-detection/ios/RNMLKitFaceDetection.podspec
+++ b/modules/react-native-mlkit-face-detection/ios/RNMLKitFaceDetection.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '15.8.3'
   s.swift_version  = '5.4'
   s.source         = { git: 'http://github.com/infinitered/react-native-mlkit' }
   s.static_framework = true

--- a/modules/react-native-mlkit-image-labeling/ios/RNMLKitImageLabeler.podspec
+++ b/modules/react-native-mlkit-image-labeling/ios/RNMLKitImageLabeler.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '15.8.3'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/infinitered/react-native-mlkit' }
   s.static_framework = true

--- a/modules/react-native-mlkit-object-detection/ios/RNMLKitObjectDetection.podspec
+++ b/modules/react-native-mlkit-object-detection/ios/RNMLKitObjectDetection.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '15.8.3'
   s.swift_version  = '5.4'
   s.source         = { git: 'http://github.com/infinitered/react-native-mlkit' }
   s.static_framework = true


### PR DESCRIPTION
### Use the latest MLKit version which [requires iOS 15](https://developers.google.com/ml-kit/migration/ios)
Currently the iOS deployment target in `@infinitered/react-native-mlkit` is 13 which means when cocoapods resolves the dependencies like MLKitVision it will find a version that support iOS 13. The last version of MLKit that supports iOS 13 is 7.0.0. In order to use the latest versions of Ml kit we need to upgrade the our min iOS version to 15. This will allow cocoapods to resolve packages like MLKitVision to the latest of 8.0.0. See the MLKitVision pod spec [here](https://github.com/CocoaPods/Specs/blob/master/Specs/8/1/e/MLKitVision/8.0.0/MLKitVision.podspec.json)


### Issue https://github.com/infinitered/react-native-mlkit/issues/169
This upgrade helps fix issue https://github.com/infinitered/react-native-mlkit/issues/169

Currently there are conflicting Google package dependencies. The firebase packages are using newer versions of the conflicting packages like `GTMSessionFetcher/Core`. For some reason, when `@react-native-firebase` is used along side `@infinitered/react-native-mlkit`, cocoa pods resolves the versions of some dependent package like `MLKitVision` to very old versions. See the screenshot below where MLKitVision is resolved to version 0.64 when the latest is 8.0.0. This results in `@infinitered/react-native-mlkit` requiring `GTMSessionFetcher/Core 1.1.` and firebase package `@react-native-firebase` using a much newer version of `>=3.4`.
<img width="938" alt="image" src="https://github.com/user-attachments/assets/3859e82f-acbd-4b02-9f95-4ca495c0a23e" />
One way to solve this is to set the min version of MLKitVision in `@infinitered/react-native-mlkit-core/ios/RNMLKitCore.podspec` to the version it uses when firebase is not in the picture which is `7.0.0`. This fixes the error with `GTMSessionFetcher/Core` but there still ends up being a conflict with `GoogleUtilities/Environment` which we can only resolve by using the latest MLKitVision of  8.0.0. This version however requires a min iOS deployment target of 15 so what we could do is set the min iOS deployment to 15 which will force cocoa pods to resolve MLKit version to `8.0.0`


### Also:
iOS deployment target 15 is required by react native 0.76
iOS deployment target 15 is required by expo 52
iOS deployment target 15 is required by Xcode 16