### PR TITLE
fix(react-native-mlkit-object-detection): infinite render caused by default value

### DIFF
--- a/modules/react-native-mlkit-object-detection/src/useObjectDetectionModels.tsx
+++ b/modules/react-native-mlkit-object-detection/src/useObjectDetectionModels.tsx
@@ -24,8 +24,10 @@ type Models<T extends Record<string, any>> = {
   [K in keyof T | "default"]: RNMLKitObjectDetector;
 };
 
+const assetsDefaultValue = {};
+
 export function useObjectDetectionModels<T extends AssetRecord>({
-  assets = {} as T,
+  assets = assetsDefaultValue as T,
   loadDefaultModel,
   defaultModelOptions,
 }: {


### PR DESCRIPTION
### Fix for https://github.com/infinitered/react-native-mlkit/issues/153

#### How to reproduce
This infinite render issue was caused when you use the object detection module without providing any assets to the hook and just use the default model. This is not an issue for the example app because it provides a model. However when you use the hook without providing a hook you get an infinite render you can see in the screen shot below I log each time the hooks changes `ObjectDetectionModelContextProvider`. 

#### Cause
Each time the hook is called, it is inserting a default value for assets which is a brand new object each time which triggers the effects in the hook again. The fix is to define the default object once and reference it.

Here is the screenshot of infinite render before:
<img width="909" alt="Screenshot 2025-01-27 at 1 22 04 AM" src="https://github.com/user-attachments/assets/f3deeee4-5395-46f1-a69b-fee9216b2790" />


Here is the screen shot of fix version:

<img width="909" alt="Screenshot 2025-01-27 at 1 20 52 AM" src="https://github.com/user-attachments/assets/c1f6e169-2ac8-4ad2-b008-82fede964ea3" />
