### PR TITLE
docs: fix expo compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Running `yarn build` inside of an expo module workspace will start watch mode fo
 |----------|----------|
 | ^49.0.0  | <= 0.7.7 |
 | ^50.0.0  | ^1.0.0   |
-| ^51.0.0  | ^1.0.0   |
-| ^52.0.0  | ^2.0.0   |
+| ^51.0.0  | ^2.0.0   |
+| ^52.0.0  | ^3.0.0   |
 
 ## Contributors
 


### PR DESCRIPTION
Updates README compatibility table.

We updated to 2.0 when [we released the Expo 51 update](https://github.com/infinitered/react-native-mlkit/pull/149#issuecomment-2159259621), and so expo 52 will be in v3.0.