### PR TITLE
docs: indicate new arch support ✅

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -7,37 +7,37 @@ sidebar_position: 1
 We are excited to have you contribute to `react-native-mlkit`! This documentation will help you get started with the
 project.
 
-We've already completed a few modules, but there are more to be done. If you're interested in contributing a module, please refer to the list below before starting! Another way to contribute is to add New Architecture Support to the existing modules.
+We've already completed a few modules, but there are more to be done. If you're interested in contributing a module, please refer to the list below before starting!
 
 ### Table of Completed Modules
 
 | Completed Modules       | RNMLKit Module Completed | iOS support | Android support | New Architecture Support |
 | ----------------------- | :----------------------: | :---------: | :-------------: | :----------------------: |
-| Image labeling          |            ✅            |     ✅      |       ✅        |            ❌            |
-| Object detection        |            ✅            |     ✅      |       ✅        |            ❌            |
-| Face detection          |            ✅            |     ✅      |       ✅        |            ❌            |
-| Document scanner (Beta) |            ✅            |     ❌      |       ✅        |            ❌            |
+| Image labeling          |            ✅            |     ✅      |       ✅        |            ✅            |
+| Object detection        |            ✅            |     ✅      |       ✅        |            ✅            |
+| Face detection          |            ✅            |     ✅      |       ✅        |            ✅            |
+| Document scanner (Beta) |            ✅            |     ❌      |       ✅        |            ✅            |
 
 ### Table of Vision API Modules
 
 | Vision API Modules          | RNMLKit Module Completed | iOS support | Android support | New Architecture Support |
 | --------------------------- | :----------------------: | :---------: | :-------------: | :----------------------: |
-| Text recognition v2         |            ❌            |     ✅      |       ✅        |            ❌            |
-| Face mesh detection (Beta)  |            ❌            |     ❌      |       ✅        |            ❌            |
-| Pose detection (Beta)       |            ❌            |     ✅      |       ✅        |            ❌            |
-| Selfie segmentation (Beta)  |            ❌            |     ✅      |       ✅        |            ❌            |
-| Subject segmentation (Beta) |            ❌            |     ❌      |       ✅        |            ❌            |
-| Barcode scanning            |            ❌            |     ✅      |       ✅        |            ❌            |
-| Digital ink recognition     |            ❌            |     ✅      |       ✅        |            ❌            |
+| Text recognition v2         |            ❌            |     ✅      |       ✅        |            ✅            |
+| Face mesh detection (Beta)  |            ❌            |     ❌      |       ✅        |            ✅            |
+| Pose detection (Beta)       |            ❌            |     ✅      |       ✅        |            ✅            |
+| Selfie segmentation (Beta)  |            ❌            |     ✅      |       ✅        |            ✅            |
+| Subject segmentation (Beta) |            ❌            |     ❌      |       ✅        |            ✅            |
+| Barcode scanning            |            ❌            |     ✅      |       ✅        |            ✅            |
+| Digital ink recognition     |            ❌            |     ✅      |       ✅        |            ✅            |
 
 ### Table of Natural Language API Modules
 
 | Natural Language API Modules | RNMLKit Module Completed | iOS support | Android support | New Architecture Support |
 | ---------------------------- | :----------------------: | :---------: | :-------------: | :----------------------: |
-| Language identification      |            ❌            |     ✅      |       ✅        |            ❌            |
-| Translation                  |            ❌            |     ✅      |       ✅        |            ❌            |
-| Smart reply                  |            ❌            |     ✅      |       ✅        |            ❌            |
-| Entity extraction (Beta)     |            ❌            |     ✅      |       ✅        |            ❌            |
+| Language identification      |            ❌            |     ✅      |       ✅        |            ✅            |
+| Translation                  |            ❌            |     ✅      |       ✅        |            ✅            |
+| Smart reply                  |            ❌            |     ✅      |       ✅        |            ✅            |
+| Entity extraction (Beta)     |            ❌            |     ✅      |       ✅        |            ✅            |
 
 Sections:
 


### PR DESCRIPTION
I started to look into what it would take to support the new architecture but came across this nice surprise ["all modules written using the Expo Modules API support the New Architecture by default!"](https://docs.expo.dev/guides/new-architecture/#expo-tools-and-the-new-architecture)  🎉 and it looks like all the modules are using the Expo modules API. So this is just a documentation change to reflect that