### PR TITLE
fix: remove reference to now-deleted docs package

### DIFF
--- a/.changeset/early-oranges-roll.md
+++ b/.changeset/early-oranges-roll.md
@@ -1,5 +1,0 @@
----
-"@infinitered/react-native-mlkit-docs": minor
----
-
-Updated contributing docs, removed Docusaurus.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
     "CI scripts are all --no-cache because we aren't using Vercel's remote cache and the caches aren't working. It may be possible to cache dependencies in the future, but for now caching breaks the build."
   ],
   "scripts": {
-    "build": "turbo run build --filter=!@infinitered/react-native-mlkit-docs",
-    "build:docs": "turbo run build --filter=@infinitered/react-native-mlkit-docs",
-    "docs": "yarn workspace @infinitered/react-native-mlkit-docs start",
+    "build": "turbo run build",
     "test": "turbo run test -- --run-in-band",
     "dev": "turbo run dev",
     "lint": "turbo run lint",


### PR DESCRIPTION
Fixes the errors in https://github.com/infinitered/react-native-mlkit/actions/runs/20277748124/job/58231130838 by removing a changeset that referred to the deleted docs.

Also removes two scripts that are irrelevant.