### PR TITLE
ci: build ExampleApp on EAS for native coverage on PRs

### DIFF
--- a/apps/ExampleApp/.eas/workflows/README.md
+++ b/apps/ExampleApp/.eas/workflows/README.md
@@ -61,3 +61,23 @@ from source as part of the app build.
   most common and Android needs no credentials) and keep iOS for `main` only.
 - Or gate builds behind a label / path filter so they only run when native files or
   `modules/*` change.
+
+## Caching
+
+EAS Build provides built-in caches (JS packages, CocoaPods, Maven/Gradle, and
+native compilation via `ccache`) with no configuration, so these builds are not
+fully cold.
+
+On top of that we set `EAS_USE_CACHE=1` (in the `production` profile in
+`eas.json`, inherited by `preview`) to enable native-compilation caching. It's
+safe even for a build whose job is to catch native breakage, because `ccache` is
+content-addressed — changed source always recompiles, so it can't mask a failure.
+
+We intentionally do **not** add a custom `cache` block (e.g. caching
+`Podfile.lock`). This repo's local Expo modules live in `modules/*`, and changing
+a module's podspec / `build.gradle` / `expo-module.config.json` alters the
+generated native project **without** touching `yarn.lock`. A lockfile-keyed cache
+would go stale and could hide exactly the native breakage this CI exists to catch.
+If build times become a real bottleneck, revisit this with a cache key that also
+invalidates on `modules/*` native config — and never cache the generated `ios/` or
+`android/` directories (CNG regenerates them every build).

--- a/apps/ExampleApp/.eas/workflows/README.md
+++ b/apps/ExampleApp/.eas/workflows/README.md
@@ -1,0 +1,63 @@
+# EAS Workflows — native build CI
+
+This directory holds [EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)
+that give us **native build coverage** on pull requests.
+
+## Why this exists
+
+Our existing CI (CircleCI `test_and_build`) only does:
+
+- `yarn lint`
+- `yarn ci:build` — which at the module level is just `tsc` (TypeScript only)
+- `yarn test` — Jest
+
+None of that compiles native code. Every module in `modules/*` ships real
+native sources:
+
+- iOS: `*.swift` + a `*.podspec`
+- Android: `build.gradle` + Kotlin/Java
+
+So a change that breaks the Swift or Kotlin (or breaks the app build) currently
+passes CI green. Building `apps/ExampleApp` on EAS fixes this: the app depends on
+every module, so a green build proves the native code for all of them compiles
+on both platforms.
+
+## What runs
+
+`build-on-pr.yml` runs on every PR targeting `main` and builds the ExampleApp for
+both platforms using the `preview` profile from `eas.json`:
+
+| Platform | Profile result | Credentials needed |
+| --- | --- | --- |
+| Android | APK | none (EAS-managed keystore) |
+| iOS | simulator build | none (simulator builds skip Apple distribution certs) |
+
+These profiles are intentionally credential-free so the job is a pure
+"does it compile" gate.
+
+## One-time setup (required for this to actually run)
+
+EAS Workflows are triggered by Expo, not by GitHub Actions or CircleCI. To enable:
+
+1. **Connect the repo to the Expo project.** In the Expo dashboard for
+   `infinitered/react-native-mlkit` (projectId `4faa9328-e941-4395-879c-f558bf07e678`),
+   go to **Project settings → GitHub** and link this GitHub repository.
+2. **Confirm billing / build credits.** Each PR triggers two builds (iOS + Android).
+   Make sure the Expo account has capacity, or the jobs will queue/fail.
+3. (Optional) If you'd rather trigger from existing CI instead of Expo's GitHub
+   integration, you can run `eas workflow:run .eas/workflows/build-on-pr.yml` from a
+   job that has `EXPO_TOKEN` set, but the native EAS GitHub integration is simpler.
+
+## Monorepo note
+
+This is a Yarn 3 monorepo. EAS resolves project config (`app.json`/`eas.json`) from
+this directory (`apps/ExampleApp`), which is why the workflow lives here rather than
+at the repo root. EAS installs the full workspace and builds the local `modules/*`
+from source as part of the app build.
+
+## Cost / tuning ideas
+
+- To reduce spend, you could build **Android only** on PRs (Android breakage is the
+  most common and Android needs no credentials) and keep iOS for `main` only.
+- Or gate builds behind a label / path filter so they only run when native files or
+  `modules/*` change.

--- a/apps/ExampleApp/.eas/workflows/build-on-pr.yml
+++ b/apps/ExampleApp/.eas/workflows/build-on-pr.yml
@@ -1,0 +1,41 @@
+name: Build ExampleApp on PRs
+
+# Native build validation for pull requests.
+#
+# CircleCI already lints, type-checks (`yarn ci:build` == `tsc`) and runs Jest,
+# but it never compiles any native code. Every module under `modules/*` ships
+# real native sources (Swift podspecs + Android Gradle/Kotlin), and none of it
+# is compiled in CircleCI. This workflow closes that gap by building the
+# ExampleApp on EAS for both platforms: because the app depends on every module,
+# a successful build transitively proves the native code for all of them
+# compiles.
+#
+# Profiles come from eas.json:
+#   - preview (iOS): simulator build  -> no Apple distribution credentials needed
+#   - preview (Android): APK build    -> EAS-managed keystore, no Play creds needed
+#
+# Setup required (one-time) before this runs:
+#   1. Connect this GitHub repo to the Expo project (infinitered/react-native-mlkit)
+#      in the Expo dashboard: Project settings -> GitHub.
+#   2. Ensure EAS build credits / billing are in place (each PR triggers 2 builds).
+# See ./README.md in this directory for details.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_android:
+    name: Build Android (preview APK)
+    type: build
+    params:
+      platform: android
+      profile: preview
+
+  build_ios:
+    name: Build iOS (preview simulator)
+    type: build
+    params:
+      platform: ios
+      profile: preview

--- a/apps/ExampleApp/eas.json
+++ b/apps/ExampleApp/eas.json
@@ -34,7 +34,10 @@
       "ios": { "simulator": false }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EAS_USE_CACHE": "1"
+      }
     }
   },
   "submit": {

--- a/apps/ExampleApp/package.json
+++ b/apps/ExampleApp/package.json
@@ -27,7 +27,7 @@
     "bundle:web": "npx expo export --platform web",
     "serve:web": "npx server dist",
     "prebuild:clean": "npx expo prebuild --clean",
-    "eas-build-post-install": "yarn -T run ci:build"
+    "eas-build-post-install": "yarn -T run ci:build:eas"
   },
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "//": [
-    "CI scripts are all --no-cache because we aren't using Vercel's remote cache and the caches aren't working. It may be possible to cache dependencies in the future, but for now caching breaks the build."
+    "The release/publish path (ci:build) stays --no-cache because we aren't using Vercel's remote cache. ci:build:eas is a cache-enabled variant used only by the EAS build hook (eas-build-post-install), mirroring the cached turbo run that postinstall already performs, so modules aren't tsc-built twice per EAS build."
   ],
   "scripts": {
     "build": "turbo run build",
@@ -13,6 +13,7 @@
     "setup": "./scripts/setup.sh",
     "version": "changeset version && yarn install --mode update-lockfile",
     "ci:build": "turbo run ci:build --filter=@infinitered/react-native-mlkit-core --no-cache && turbo run ci:build --filter=!@infinitered/react-native-mlkit-core --no-cache",
+    "ci:build:eas": "turbo run ci:build --filter=@infinitered/react-native-mlkit-core && turbo run ci:build --filter=!@infinitered/react-native-mlkit-core",
     "ci:publish": "changeset publish",
     "ci:push-tags": "git push --follow-tags",
     "ci:trust": "./scripts/git-push-fork-to-upstream-repo.sh",


### PR DESCRIPTION
## Why

Our current CI (CircleCI `test_and_build`) only does `yarn lint`, `yarn ci:build`, and `yarn test`. At the module level `ci:build` is just `tsc` — it type-checks TypeScript and never compiles any native code. Every module in `modules/*` ships real native sources (Swift `*.podspec`, Android `build.gradle` + Kotlin), so a change that breaks the Swift or Kotlin currently passes CI green. We have **zero CI signal** today that the native side actually compiles on either platform.

## What

Adds an [EAS Workflow](https://docs.expo.dev/eas/workflows/get-started/) that builds `apps/ExampleApp` on **both platforms** for every PR targeting `main`. Because the app depends on every module, a successful build transitively proves all the native code compiles.

- `apps/ExampleApp/.eas/workflows/build-on-pr.yml` — the workflow (iOS + Android)
- `apps/ExampleApp/.eas/workflows/README.md` — rationale, setup, and cost/tuning notes

Uses the existing **credential-free** `preview` profiles from `eas.json`, so it's a pure "does it compile" gate:

| Platform | Profile result | Credentials needed |
| --- | --- | --- |
| Android | APK | none (EAS-managed keystore) |
| iOS | simulator build | none (simulator builds skip Apple distribution certs) |

## Notes

- The Expo project is already linked to this repo, so opening this PR should trigger the first iOS + Android builds — **this PR is itself the first validation** of the workflow.
- Each PR triggers 2 builds; if cost becomes a concern we can gate the jobs to only run when `modules/*` or native files change, or drop to Android-only on PRs.
- The first iOS build may queue (macOS); the first Android build will auto-generate a keystore.

https://claude.ai/code/session_01C3a567ZtwKncV5wzvFRUhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3a567ZtwKncV5wzvFRUhX)_