### PR TITLE
Cancel superseded EAS builds on PR branches

### DIFF
--- a/apps/ExampleApp/.eas/workflows/README.md
+++ b/apps/ExampleApp/.eas/workflows/README.md
@@ -48,6 +48,15 @@ EAS Workflows are triggered by Expo, not by GitHub Actions or CircleCI. To enabl
    integration, you can run `eas workflow:run .eas/workflows/build-on-pr.yml` from a
    job that has `EXPO_TOKEN` set, but the native EAS GitHub integration is simpler.
 
+## Superseded builds are cancelled
+
+The workflow sets a `concurrency` group keyed on the workflow file + branch
+(`${{ workflow.filename }}-${{ github.ref }}`) with `cancel_in_progress: true`.
+When you push new commits to a PR branch, any builds still running for an older
+commit on that same branch are cancelled, so only the latest commit gets built.
+This avoids wasting build credits on already-stale commits. (EAS currently only
+supports `cancel_in_progress` for same-branch concurrency.)
+
 ## Monorepo note
 
 This is a Yarn 3 monorepo. EAS resolves project config (`app.json`/`eas.json`) from

--- a/apps/ExampleApp/.eas/workflows/build-on-pr.yml
+++ b/apps/ExampleApp/.eas/workflows/build-on-pr.yml
@@ -25,6 +25,13 @@ on:
     branches:
       - main
 
+# When new commits land on a PR branch, cancel any builds still running for an
+# older commit on that same branch so only the latest commit gets built. EAS
+# currently supports cancel_in_progress only for same-branch concurrency.
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 jobs:
   build_android:
     name: Build Android (preview APK)


### PR DESCRIPTION
## Summary
Added concurrency configuration to the EAS build workflow to automatically cancel in-progress builds when new commits are pushed to a PR branch, ensuring only the latest commit gets built.

## Changes
- Added `concurrency` group to `build-on-pr.yml` workflow keyed on workflow filename and git ref with `cancel_in_progress: true` enabled
- Updated README.md with documentation explaining the concurrency behavior and its benefits

## Details
When multiple commits are pushed to the same PR branch, any builds still running for older commits will now be automatically cancelled. This prevents wasting build credits on stale commits and ensures the CI pipeline focuses on the latest changes. The concurrency group is scoped to the same branch to align with EAS's current support for `cancel_in_progress`.

https://claude.ai/code/session_01LSbSKs7fZGjAQhreAmnevM