### PR TITLE
fix: make Text explicit

### DIFF
--- a/.changeset/slimy-books-cough.md
+++ b/.changeset/slimy-books-cough.md
@@ -1,0 +1,5 @@
+---
+"@infinitered/react-native-mlkit-text-recognition": patch
+---
+
+use explicit Text type to fix ambiguity compile error

--- a/modules/react-native-mlkit-text-recognition/ios/RNMLKitTextRecord.swift
+++ b/modules/react-native-mlkit-text-recognition/ios/RNMLKitTextRecord.swift
@@ -70,7 +70,7 @@ func mapTextBlockToRecord(_ textBlock: TextBlock) -> BlockRecord {
     )
 }
 
-func mapTextToRecord(_ text: Text) -> TextRecord {
+func mapTextToRecord(_ text: MLKitTextRecognitionCommon.Text) -> TextRecord {
     return TextRecord(
         text: text.text,
         blocks: text.blocks.map(mapTextBlockToRecord)


### PR DESCRIPTION
Building failed with expo 56:

```
❌  (node_modules/@infinitered/react-native-mlkit-text-recognition/ios/RNMLKitTextRecord.swift:73:30)

  71 | }
  72 |
> 73 | func mapTextToRecord(_ text: Text) -> TextRecord {
```

My best guess is that some recent update _(expo ui? that's relatively new)_ re-exports swift-ui, which has Text as well.

This change solved the build and I verified it works by scanning a label and getting the text.